### PR TITLE
SCRUM-46 feat: Add file upload feature with Supabase Storage integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,17 +161,10 @@ jobs:
           SERVICE_ROLE_KEY: ${{ secrets.SERVICE_ROLE_KEY }}
         run: npm run build
 
-      - name: Reset and migrate staging database
+      - name: Run database migrations
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-        run: |
-          npx prisma migrate reset --force --skip-seed
-          npx prisma migrate deploy
-
-      - name: Seed staging database
-        env:
-          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-        run: npx prisma db seed
+        run: npx prisma migrate deploy
 
       - name: Run integration tests
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,6 +158,7 @@ jobs:
         env:
           NEXT_PUBLIC_API_EXTERNAL_URL: ${{ secrets.NEXT_PUBLIC_API_EXTERNAL_URL }}
           NEXT_PUBLIC_ANON_KEY: ${{ secrets.NEXT_PUBLIC_ANON_KEY }}
+          SERVICE_ROLE_KEY: ${{ secrets.SERVICE_ROLE_KEY }}
         run: npm run build
 
       - name: Reset and migrate staging database

--- a/FILE_UPLOAD_TESTING_GUIDE.md
+++ b/FILE_UPLOAD_TESTING_GUIDE.md
@@ -1,0 +1,500 @@
+# File Upload Feature - Complete Testing Guide
+
+This comprehensive guide walks you through testing the file upload feature from database setup to final testing.
+
+---
+
+## 📋 Prerequisites
+
+Before starting, ensure you have:
+
+- ✅ Docker Desktop installed and running
+- ✅ Supabase services running via Docker Compose
+- ✅ Node.js and npm installed
+- ✅ Project dependencies installed (`npm install`)
+
+---
+
+## 🗄️ Step 1: Database Setup
+
+### 1.1 Start Supabase Services
+
+```bash
+# Navigate to supabase directory
+cd supabase
+
+# Start all services
+docker compose --env-file ../.env up -d
+
+# Return to project root
+cd ..
+```
+
+### 1.2 Run Database Migrations
+
+```bash
+# Apply Prisma schema to database
+npx prisma migrate deploy
+
+# Generate Prisma Client
+npx prisma generate
+```
+
+### 1.3 Seed Initial Data
+
+```bash
+# Populate database with seed data (departments, users, tasks)
+npx prisma db seed
+```
+
+**What this creates:**
+
+- Default departments (Engineering, HR, etc.)
+- Seed users: John Doe, Philip Lee, Sally Loh
+- Sample tasks and projects
+
+---
+
+## 🪣 Step 2: Configure Supabase Storage
+
+### 2.1 Create Storage Bucket
+
+1. Open Supabase Dashboard: **http://localhost:8000**
+2. Navigate to **Storage** (left sidebar)
+3. Click **Create a new bucket**
+4. Configure bucket:
+   - **Name**: `task-attachments`
+   - **Public bucket**: ❌ **Unchecked** (keep it private)
+5. Click **Additional Configuration** (expand section)
+6. Configure file restrictions:
+   - **File size limit**: Click "Reset file upload size for bucket"
+   - Enter: `10` (10MB)
+   - **Allowed MIME types**: Paste the following:
+   ```
+   image/*,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/plain,application/zip
+   ```
+7. Click **Create bucket**
+
+### 2.2 Configure Policies
+
+Go to **Storage** → Click `task-attachments` bucket → **Policies** tab → task-attachments > Click **New Policy** > For full customisation
+
+#### Policy 1: Allow Upload (INSERT)
+
+- **Policy Name**: `Users can upload to assigned tasks`
+- **Allowed operation**: `INSERT`
+- **Target Roles**: Authenticated
+- **Policy Definition**:
+
+```sql
+bucket_id = 'task-attachments'
+AND
+(storage.foldername(name))[1] IN (
+  SELECT t.id
+  FROM task t
+  INNER JOIN task_assignment ta ON ta."taskId" = t.id
+  WHERE ta."userId" = auth.uid()::text
+)
+```
+
+Click **Review** → **Save policy**
+
+#### Policy 2: Allow Download (SELECT)
+
+- **Policy Name**: `Users can view files from assigned tasks`
+- **Allowed operation**: `SELECT`
+- **Target Roles**: `Authenticated`
+- **Policy Definition**:
+
+```sql
+(bucket_id = 'task-attachments')
+AND
+(storage.foldername(name))[1] IN (
+  SELECT t.id
+  FROM task t
+  INNER JOIN task_assignment ta ON ta."taskId" = t.id
+  WHERE ta."userId" = auth.uid()::text
+)
+```
+
+Click **Review** → **Save policy**
+
+#### Policy 3: Allow Delete (DELETE)
+
+- **Policy Name**: `Users can delete their own uploaded files`
+- **Allowed operation**: `DELETE`
+- **Target Roles**: `Authenticated`
+- **Policy Definition**:
+
+```sql
+(bucket_id = 'task-attachments') AND (owner = uid())
+```
+
+Click **Review** → **Save policy**
+
+---
+
+## 👤 Step 3: Create Test User Account
+
+### 3.1 Sign Up via Application
+
+1. Start the development server:
+
+```bash
+npm run dev
+```
+
+2. Navigate to **http://localhost:3000**
+3. Click **Login / Sign Up**
+4. Click **Create Account**
+5. Fill in the form:
+   - **Email**: `test@test.com` (or your choice)
+   - **Password**: Choose a secure password
+   - **Name**: `Test User` (or your choice)
+   - **Department**: Select any department from dropdown
+
+6. Click **Sign Up**
+
+### 3.2 Get Your User ID
+
+After signing up successfully, you need to get your user ID:
+
+#### Option A: Via Supabase Dashboard (Easiest)
+
+1. Go to **http://localhost:8000**
+2. Click **Table Editor** (left sidebar)
+3. Select **`user_profile`** table
+4. Find your email (`test@test.com`)
+5. Copy the **`id`** (UUID format) and **`departmentId`**
+
+#### Option B: Via Terminal
+
+```bash
+docker exec -i $(docker ps --filter name=supabase-db --format "{{.ID}}") psql -U postgres -d postgres -c "SELECT id, email, name, \"departmentId\" FROM user_profile WHERE email = 'test@test.com';"
+```
+
+**Example Output:**
+
+```
+                  id                  |     email      |   name    |     departmentId
+--------------------------------------+----------------+-----------+---------------------
+ 75311644-d73e-4d9f-a941-1a729114d9fb | test@test.com  | Test User | dept-consultancy-001
+```
+
+**📝 Save these values:**
+
+- **User ID**: `75311644-d73e-4d9f-a941-1a729114d9fb`
+- **Department ID**: `dept-consultancy-001`
+
+---
+
+## 📝 Step 4: Configure Test Task SQL
+
+### 4.1 Open SQL Script
+
+Open the file: **`scripts/seed-test-task.sql`**
+
+### 4.2 Update User Information
+
+Find and replace the following placeholders with YOUR values:
+
+#### Line 29 - Owner ID
+
+```sql
+'75311644-d73e-4d9f-a941-1a729114d9fb',  -- user ID
+```
+
+Replace with **your User ID**
+
+#### Line 30 - Department ID
+
+```sql
+'dept-consultancy-001',  -- department ID
+```
+
+Replace with **your Department ID**
+
+#### Lines 46-47 - Assignment User IDs
+
+```sql
+'75311644-d73e-4d9f-a941-1a729114d9fb',  -- user ID
+'75311644-d73e-4d9f-a941-1a729114d9fb',  -- assigned by themselves (for testing)
+```
+
+Replace BOTH with **your User ID**
+
+### 4.3 Save the File
+
+After making these changes, **save the file** (`Ctrl+S` or `Cmd+S`)
+
+---
+
+## 🎯 Step 5: Create Test Task in Database
+
+### 5.1 Run SQL Script
+
+1. Go to Supabase Dashboard: **http://localhost:8000**
+2. Click **SQL Editor** (left sidebar)
+3. Click **New query**
+4. Open `scripts/seed-test-task.sql` in your code editor
+5. **Copy the entire contents** of the file
+6. **Paste into SQL Editor**
+7. Click **Run** or press `Ctrl+Enter`
+
+### 5.2 Verify Success
+
+You should see **Result tables**:
+
+#### Table 1: Assignment Created
+
+```
+          status              |               task_id                | assigned_user
+------------------------------+--------------------------------------+---------------
+ ✅ Task assignment created    | 123e4567-e89b-12d3-a456-426614174000 | Test User
+```
+
+If you see ✅, you're ready to test!
+
+---
+
+## 🧪 Step 6: Test File Upload Feature
+
+### 6.1 Navigate to Staff Dashboard
+
+1. Ensure dev server is running: `npm run dev`
+2. Go to **http://localhost:3000**
+3. **Login** with your test account:
+   - Email: `test@test.com`
+   - Password: (what you set in Step 3)
+4. You'll be redirected to **http://localhost:3000/dashboard/staff**
+
+### 6.2 Find the File Upload Section
+
+Scroll down to the bottom of the dashboard page to see:
+
+**📎 My Task - File Upload Test**
+
+You should see:
+
+- Task title: "Test Task for File Upload"
+- Task description
+- Status and Priority badges
+- **Upload Files** section
+
+### 6.3 Test Upload Workflow
+
+#### A. Upload a File ⬆️
+
+1. Click **📁 Choose File** button
+2. Select a file from your computer
+   - **Max size**: 10MB
+   - **Allowed types**: PDF, JPG, PNG, GIF, DOC, DOCX, XLS, XLSX, TXT, ZIP
+3. Click **⬆️ Upload** button
+4. Watch the **progress bar** (0% → 100%)
+5. Success message appears: **✅ File "filename.pdf" uploaded successfully!**
+
+#### B. View Uploaded Files 📋
+
+After upload, the file appears in the uploaded files list showing:
+
+- File name
+- File size
+- Upload timestamp
+- Download and Delete buttons
+
+#### C. Download a File 📥
+
+1. Click **📥 Download** button next to any uploaded file
+2. File downloads to your computer
+
+#### D. Delete a File 🗑️
+
+1. Click **🗑️ Delete** button
+2. Confirm deletion in the popup
+3. File is removed from list and Supabase Storage
+
+---
+
+## ✅ Test Validation & Error Handling
+
+### Test 1: File Size Limit (10MB per file)
+
+**Steps:**
+
+1. Try to upload a file larger than 10MB
+
+**Expected Result:**
+
+```
+❌ File size exceeds 10MB limit. Current: 12.34MB
+```
+
+### Test 2: Task Size Limit (50MB total)
+
+**Steps:**
+
+1. Upload multiple files
+2. Try to exceed 50MB total for the task
+
+**Expected Result:**
+
+```
+❌ Task file limit exceeded. Current: 45.00MB, Adding: 8.00MB, Limit: 50MB
+```
+
+### Test 3: File Type Restriction
+
+**Steps:**
+
+1. Try to upload an unsupported file type (e.g., `.exe`, `.dmg`)
+
+**Expected Result:**
+
+```
+❌ File type "application/x-msdownload" not allowed. Allowed: PDF, images, Word, Excel, text, ZIP
+```
+
+### Test 4: Authorization Check
+
+**Steps:**
+
+1. Create another user account
+2. Login with that account
+3. Try to access the same task
+
+**Expected Result:**
+
+```
+❌ No tasks found. (Because the new user isn't assigned to the test task)
+```
+
+---
+
+## 🐛 Troubleshooting
+
+### ❌ Error: "Foreign key constraint violated on task_file_taskId_fkey"
+
+**Cause**: The task doesn't exist in the database
+
+**Solution**:
+
+1. Verify you ran Step 5 (Create Test Task)
+2. Check Supabase → Table Editor → `task` table
+3. Confirm task ID `123e4567-e89b-12d3-a456-426614174000` exists
+
+### ❌ Error: "null value in column 'dueDate' violates not-null constraint"
+
+**Cause**: Missing required field in SQL script
+
+**Solution**:
+
+1. Check `scripts/seed-test-task.sql`
+2. Ensure line 27 has: `'2025-12-31T00:00:00.000Z',`
+3. Ensure line 30 has your department ID
+4. Re-run the SQL script
+
+### ❌ Error: "Unauthorized: You must be assigned to this task to upload files"
+
+**Cause**: User ID mismatch between SQL script and logged-in user
+
+**Solution**:
+
+1. Verify you're logged in as `test@test.com`
+2. Check `scripts/seed-test-task.sql` lines 29, 46, 47
+3. Ensure all three match YOUR user ID from Step 3.2
+4. Re-run the SQL script
+
+### ❌ Error: "No tasks found" on Dashboard
+
+**Cause**: Test task not assigned to logged-in user
+
+**Solution**:
+
+1. Verify SQL script has correct user ID (Step 4)
+2. Check database:
+
+```bash
+docker exec -i $(docker ps --filter name=supabase-db --format "{{.ID}}") psql -U postgres -d postgres -c "SELECT * FROM task_assignment WHERE \"taskId\" = '123e4567-e89b-12d3-a456-426614174000';"
+```
+
+3. Re-run SQL script if assignment is missing
+
+### ❌ Upload fails silently / Files don't appear
+
+**Cause**: RLS policies blocking storage access
+
+**Solution**:
+
+1. Verify bucket name is exactly `task-attachments` (no typos)
+2. Re-check all 3 RLS policies (Step 2.2)
+3. Ensure column names use PascalCase with quotes: `ta."taskId"`, `ta."userId"`
+4. Test policy in Supabase → Storage → Policies → Test policy
+
+---
+
+## 📊 Verify Data in Database
+
+### Check Uploaded Files
+
+```bash
+docker exec -i $(docker ps --filter name=supabase-db --format "{{.ID}}") psql -U postgres -d postgres -c "SELECT id, \"fileName\", \"fileSize\", \"fileType\", \"uploadedById\", \"uploadedAt\" FROM task_file WHERE \"taskId\" = '123e4567-e89b-12d3-a456-426614174000';"
+```
+
+### Check Task Assignment
+
+```bash
+docker exec -i $(docker ps --filter name=supabase-db --format "{{.ID}}") psql -U postgres -d postgres -c "SELECT ta.\"taskId\", ta.\"userId\", u.email, u.name FROM task_assignment ta JOIN user_profile u ON ta.\"userId\" = u.id WHERE ta.\"taskId\" = '123e4567-e89b-12d3-a456-426614174000';"
+```
+
+### Check Storage Files (Supabase Dashboard)
+
+1. Go to **http://localhost:8000**
+2. Click **Storage** → `task-attachments` bucket
+3. Click folder: `123e4567-e89b-12d3-a456-426614174000`
+4. Verify uploaded files appear with timestamps
+
+---
+
+## 📁 Implementation File Structure
+
+```
+all-in-one/
+├── scripts/
+│   └── seed-test-task.sql              # ⭐ SQL to create test task
+├── src/
+│   ├── app/
+│   │   ├── components/
+│   │   │   └── TaskFileUpload.tsx      # ⭐ Upload UI component (auth-integrated)
+│   │   ├── dashboard/
+│   │   │   └── staff/
+│   │   │       └── page.tsx            # ⭐ Staff dashboard with file upload
+│   │   └── server/routers/
+│   │       └── taskFile.ts             # ⭐ tRPC endpoints
+│   ├── services/
+│   │   ├── storage/
+│   │   │   └── SupabaseStorageService.ts  # Storage operations
+│   │   └── task/
+│   │       └── TaskService.ts          # Business logic
+│   └── repositories/
+│       ├── ITaskRepository.ts          # Repository interface
+│       └── PrismaTaskRepository.ts     # Prisma implementation
+└── FILE_UPLOAD_TESTING_GUIDE.md       # ⭐ This file
+```
+
+---
+
+## 📞 Need Help?
+
+If you encounter issues:
+
+1. Check the **Troubleshooting** section above
+2. Verify all environment variables in `.env`
+3. Check Docker logs: `docker logs <container-id>`
+4. Check Next.js console for errors
+5. Check Supabase Dashboard → Logs
+
+---
+
+**Last Updated**: 2025-10-06
+**Feature Branch**: `SCRUM-46-feat-file-attachments-upload`
+**Test Task ID**: `123e4567-e89b-12d3-a456-426614174000`

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,11 +1,15 @@
-// Mock Supabase client
-jest.mock('@supabase/supabase-js', () => ({
-  createClient: jest.fn(() => ({
-    storage: {
-      from: jest.fn(),
-    },
-  })),
-}));
+// Mock Supabase with a pass-through that works for both unit and integration tests
+jest.mock('@supabase/supabase-js', () => {
+  const actual = jest.requireActual('@supabase/supabase-js');
+  return {
+    ...actual,
+    createClient: jest.fn((...args) => {
+      // For integration tests, use real client
+      // For unit tests, return mock (unit tests will override with jest.mock anyway)
+      return actual.createClient(...args);
+    }),
+  };
+});
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('dotenv').config({ path: './.env' });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,12 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-require('dotenv').config({ path: './.env' });
-
-import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
-
-// Mock Supabase client to prevent initialization errors in tests
+// Mock Supabase client
 jest.mock('@supabase/supabase-js', () => ({
   createClient: jest.fn(() => ({
     storage: {
@@ -14,6 +6,14 @@ jest.mock('@supabase/supabase-js', () => ({
     },
   })),
 }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('dotenv').config({ path: './.env' });
+
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 
 // Mock Next.js router
 jest.mock('next/navigation', () => ({

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -6,6 +6,15 @@ import { TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
+// Mock Supabase client to prevent initialization errors in tests
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    storage: {
+      from: jest.fn(),
+    },
+  })),
+}));
+
 // Mock Next.js router
 jest.mock('next/navigation', () => ({
   useRouter() {

--- a/scripts/seed-test-task.sql
+++ b/scripts/seed-test-task.sql
@@ -1,0 +1,75 @@
+-- Test Data for File Upload Feature
+-- Creates a test task assigned to user: userID
+--
+-- Usage in Supabase SQL Editor:
+-- 1. Go to Supabase Dashboard → SQL Editor
+-- 2. Copy and paste this entire script
+-- 3. Click "Run" or press Ctrl+Enter
+
+-- Create test task
+INSERT INTO task (
+  id,
+  title,
+  description,
+  status,
+  priority,
+  "dueDate",
+  "ownerId",
+  "departmentId",
+  "createdAt",
+  "updatedAt"
+)
+VALUES (
+  '123e4567-e89b-12d3-a456-426614174000',
+  'Test Task for File Upload',
+  'This is a test task for testing file upload functionality. Upload files to test the complete workflow.',
+  'TO_DO',
+  'MEDIUM',
+  '2025-12-31T00:00:00.000Z',
+  '75311644-d73e-4d9f-a941-1a729114d9fb',  -- user ID
+  'dept-consultancy-001',  -- department ID
+  NOW(),
+  NOW()
+)
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  description = EXCLUDED.description,
+  "updatedAt" = NOW();
+
+-- Assign test user to the task
+INSERT INTO task_assignment (
+  "taskId",
+  "userId",
+  "assignedById",
+  "assignedAt"
+)
+VALUES (
+  '123e4567-e89b-12d3-a456-426614174000',
+  '75311644-d73e-4d9f-a941-1a729114d9fb',  -- user ID
+  '75311644-d73e-4d9f-a941-1a729114d9fb',  -- assigned by themselves (for testing)
+  NOW()
+)
+ON CONFLICT ("taskId", "userId") DO UPDATE SET
+  "assignedAt" = NOW();
+
+-- Verify the created data
+SELECT
+  '✅ Created test task' as status,
+  t.id as task_id,
+  t.title,
+  t.status,
+  t.priority,
+  u.name as owner_name,
+  u.email as owner_email
+FROM task t
+JOIN user_profile u ON t."ownerId" = u.id
+WHERE t.id = '123e4567-e89b-12d3-a456-426614174000';
+
+SELECT
+  '✅ Task assignment created' as status,
+  ta."taskId" as task_id,
+  u.name as assigned_user,
+  u.email as user_email
+FROM task_assignment ta
+JOIN user_profile u ON ta."userId" = u.id
+WHERE ta."taskId" = '123e4567-e89b-12d3-a456-426614174000';

--- a/src/app/components/TaskFileUpload.tsx
+++ b/src/app/components/TaskFileUpload.tsx
@@ -1,0 +1,516 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/supabase/auth-context';
+
+interface TaskFileUploadProps {
+  taskId: string;
+}
+
+interface UploadedFile {
+  id: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  uploadedById: string;
+  uploadedAt: string;
+}
+
+/**
+ * Task File Upload Component
+ * Integrated with authentication - uses logged-in user context
+ */
+export function TaskFileUpload({ taskId }: TaskFileUploadProps) {
+  const { userProfile } = useAuth();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+  const [loadingFiles, setLoadingFiles] = useState(true);
+  const [totalSize, setTotalSize] = useState(0);
+
+  // Fetch uploaded files on mount
+  useEffect(() => {
+    fetchFiles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [taskId, userProfile]);
+
+  const fetchFiles = async () => {
+    if (!userProfile) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/trpc/taskFile.getTaskFiles?input=${encodeURIComponent(
+          JSON.stringify({
+            taskId,
+            userId: userProfile.id,
+            userRole: userProfile.role,
+            departmentId: userProfile.departmentId,
+          })
+        )}`
+      );
+      const data = await response.json();
+
+      if (data.result?.data?.files) {
+        setUploadedFiles(data.result.data.files);
+        setTotalSize(data.result.data.totalSize || 0);
+      }
+    } catch (err) {
+      console.error('Failed to fetch files:', err);
+    } finally {
+      setLoadingFiles(false);
+    }
+  };
+
+  const handleDownload = async (fileId: string, fileName: string) => {
+    if (!userProfile) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/trpc/taskFile.getFileDownloadUrl?input=${encodeURIComponent(
+          JSON.stringify({
+            fileId,
+            userId: userProfile.id,
+            userRole: userProfile.role,
+            departmentId: userProfile.departmentId,
+          })
+        )}`
+      );
+      const data = await response.json();
+
+      if (data.result?.data?.downloadUrl) {
+        const link = document.createElement('a');
+        link.href = data.result.data.downloadUrl;
+        link.download = fileName;
+        link.click();
+      }
+    } catch {
+      setError('Failed to download file');
+    }
+  };
+
+  const handleDelete = async (fileId: string, fileName: string) => {
+    if (!userProfile) {
+      return;
+    }
+    if (!confirm(`Are you sure you want to delete "${fileName}"?`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/trpc/taskFile.deleteFile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fileId,
+          userId: userProfile.id,
+          userRole: userProfile.role,
+          departmentId: userProfile.departmentId,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Delete failed');
+      }
+
+      setSuccess(`✅ File "${fileName}" deleted successfully!`);
+      fetchFiles(); // Refresh list
+
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err) {
+      setError(
+        `Failed to delete file: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    setSelectedFile(file);
+    setError(null);
+    setSuccess(null);
+
+    // Validate file size (10MB max)
+    const MAX_SIZE = 10 * 1024 * 1024;
+    if (file.size > MAX_SIZE) {
+      setError(
+        `File size exceeds 10MB limit. Current: ${(file.size / (1024 * 1024)).toFixed(2)}MB`
+      );
+      setSelectedFile(null);
+      return;
+    }
+
+    // Validate file type
+    const ALLOWED_TYPES = [
+      'application/pdf',
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'text/plain',
+      'application/zip',
+    ];
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError(
+        `File type "${file.type}" not allowed. Allowed: PDF, images, Word, Excel, text, ZIP`
+      );
+      setSelectedFile(null);
+      return;
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile || !userProfile) {
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+    setSuccess(null);
+    setUploadProgress(0);
+
+    try {
+      setUploadProgress(20);
+
+      // Read file as base64
+      const reader = new FileReader();
+      reader.onload = async event => {
+        try {
+          const base64Data = event.target?.result as string;
+          const base64Content = base64Data.split(',')[1];
+
+          setUploadProgress(40);
+
+          // Make API call with user context
+          const response = await fetch('/api/trpc/taskFile.uploadFile', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              taskId,
+              fileName: selectedFile.name,
+              fileType: selectedFile.type,
+              fileData: base64Content,
+              userId: userProfile.id,
+              userRole: userProfile.role,
+              departmentId: userProfile.departmentId,
+            }),
+          });
+
+          setUploadProgress(80);
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.error?.message || 'Upload failed');
+          }
+
+          setUploadProgress(100);
+          setSuccess(`✅ File "${selectedFile.name}" uploaded successfully!`);
+          setSelectedFile(null);
+          setUploading(false);
+
+          // Refresh file list
+          fetchFiles();
+
+          // Clear success message after 3 seconds
+          setTimeout(() => {
+            setSuccess(null);
+            setUploadProgress(0);
+          }, 3000);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Upload failed');
+          setUploading(false);
+          setUploadProgress(0);
+        }
+      };
+
+      reader.onerror = () => {
+        setError('Failed to read file');
+        setUploading(false);
+        setUploadProgress(0);
+      };
+
+      reader.readAsDataURL(selectedFile);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+      setUploading(false);
+      setUploadProgress(0);
+    }
+  };
+
+  if (!userProfile) {
+    return <p>Please login to upload files</p>;
+  }
+
+  return (
+    <div style={{ maxWidth: '600px' }}>
+      {/* File Selection */}
+      <div style={{ marginBottom: '1rem' }}>
+        <label
+          htmlFor='file-input'
+          style={{
+            display: 'inline-block',
+            padding: '10px 20px',
+            backgroundColor: selectedFile ? '#28a745' : '#007bff',
+            color: 'white',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          {selectedFile ? `✓ ${selectedFile.name}` : '📁 Choose File'}
+        </label>
+        <input
+          id='file-input'
+          type='file'
+          onChange={handleFileSelect}
+          disabled={uploading}
+          accept='.pdf,.jpg,.jpeg,.png,.gif,.doc,.docx,.xls,.xlsx,.txt,.zip'
+          style={{ display: 'none' }}
+        />
+        {selectedFile && (
+          <button
+            onClick={handleUpload}
+            disabled={uploading}
+            style={{
+              marginLeft: '10px',
+              padding: '10px 20px',
+              backgroundColor: uploading ? '#6c757d' : '#28a745',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: uploading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {uploading ? '⏳ Uploading...' : '⬆️ Upload'}
+          </button>
+        )}
+      </div>
+
+      {/* File Info */}
+      {selectedFile && !uploading && (
+        <div style={{ marginBottom: '1rem', fontSize: '14px', color: '#666' }}>
+          Size: {(selectedFile.size / (1024 * 1024)).toFixed(2)} MB | Type:{' '}
+          {selectedFile.type}
+        </div>
+      )}
+
+      {/* Progress Bar */}
+      {uploading && (
+        <div
+          style={{
+            width: '100%',
+            height: '30px',
+            backgroundColor: '#eee',
+            borderRadius: '4px',
+            overflow: 'hidden',
+            marginBottom: '1rem',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${uploadProgress}%`,
+              backgroundColor: '#28a745',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'white',
+              fontWeight: 'bold',
+              transition: 'width 0.3s ease',
+            }}
+          >
+            {uploadProgress}%
+          </div>
+        </div>
+      )}
+
+      {/* Error Message */}
+      {error && (
+        <div
+          style={{
+            padding: '10px',
+            backgroundColor: '#f8d7da',
+            color: '#721c24',
+            borderRadius: '4px',
+            marginBottom: '1rem',
+          }}
+        >
+          ❌ {error}
+        </div>
+      )}
+
+      {/* Success Message */}
+      {success && (
+        <div
+          style={{
+            padding: '10px',
+            backgroundColor: '#d4edda',
+            color: '#155724',
+            borderRadius: '4px',
+            marginBottom: '1rem',
+          }}
+        >
+          {success}
+        </div>
+      )}
+
+      {/* Hints */}
+      <div style={{ fontSize: '12px', color: '#666', marginBottom: '1rem' }}>
+        💡 Max 10MB per file • 50MB total per task • Allowed: PDF, images, Word,
+        Excel, text, ZIP
+      </div>
+
+      {/* Storage Usage */}
+      {!loadingFiles && (
+        <div
+          style={{
+            marginBottom: '1.5rem',
+            padding: '0.75rem',
+            backgroundColor: '#f0f0f0',
+            borderRadius: '4px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginBottom: '0.5rem',
+            }}
+          >
+            <span style={{ fontSize: '13px', fontWeight: '500' }}>
+              Storage Usage:
+            </span>
+            <span
+              style={{
+                fontSize: '13px',
+                fontWeight: '600',
+                color: totalSize > 50 * 1024 * 1024 ? '#dc3545' : '#28a745',
+              }}
+            >
+              {(totalSize / (1024 * 1024)).toFixed(2)} MB / 50 MB
+            </span>
+          </div>
+          <div
+            style={{
+              width: '100%',
+              height: '8px',
+              backgroundColor: '#e0e0e0',
+              borderRadius: '4px',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                width: `${Math.min((totalSize / (50 * 1024 * 1024)) * 100, 100)}%`,
+                height: '100%',
+                backgroundColor:
+                  totalSize > 50 * 1024 * 1024
+                    ? '#dc3545'
+                    : totalSize > 40 * 1024 * 1024
+                      ? '#ffc107'
+                      : '#28a745',
+                transition: 'width 0.3s ease',
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Uploaded Files List */}
+      <div style={{ marginTop: '2rem' }}>
+        <h3
+          style={{ fontSize: '1rem', fontWeight: '600', marginBottom: '1rem' }}
+        >
+          📂 Uploaded Files
+        </h3>
+
+        {loadingFiles ? (
+          <p style={{ color: '#666', fontSize: '14px' }}>Loading files...</p>
+        ) : uploadedFiles.length === 0 ? (
+          <p style={{ color: '#666', fontSize: '14px' }}>
+            No files uploaded yet.
+          </p>
+        ) : (
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+          >
+            {uploadedFiles.map(file => (
+              <div
+                key={file.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '0.75rem',
+                  backgroundColor: '#f9f9f9',
+                  borderRadius: '4px',
+                  border: '1px solid #e0e0e0',
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <div
+                    style={{
+                      fontSize: '14px',
+                      fontWeight: '500',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    {file.fileName}
+                  </div>
+                  <div style={{ fontSize: '12px', color: '#666' }}>
+                    {(file.fileSize / (1024 * 1024)).toFixed(2)} MB •{' '}
+                    {new Date(file.uploadedAt).toLocaleDateString()}
+                  </div>
+                </div>
+
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <button
+                    onClick={() => handleDownload(file.id, file.fileName)}
+                    style={{
+                      padding: '6px 12px',
+                      backgroundColor: '#007bff',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                    }}
+                  >
+                    ⬇️ Download
+                  </button>
+                  <button
+                    onClick={() => handleDelete(file.id, file.fileName)}
+                    style={{
+                      padding: '6px 12px',
+                      backgroundColor: '#dc3545',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                    }}
+                  >
+                    🗑️ Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/staff/page.tsx
+++ b/src/app/dashboard/staff/page.tsx
@@ -2,18 +2,47 @@
 
 import { useAuth } from '@/lib/supabase/auth-context';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Navbar from '@/app/components/Navbar';
+import { TaskFileUpload } from '@/app/components/TaskFileUpload';
 
 export default function StaffDashboard() {
   const { user, userProfile, loading } = useAuth();
   const router = useRouter();
+  const [task, setTask] = useState<{ id: string; title: string } | null>(null);
+  const [loadingTask, setLoadingTask] = useState(true);
 
   useEffect(() => {
     if (!loading && !user) {
       router.push('/auth/login');
     }
   }, [user, loading, router]);
+
+  // Fetch user's tasks
+  useEffect(() => {
+    async function fetchTasks() {
+      if (!userProfile) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/api/trpc/taskFile.getUserTasks?input=${encodeURIComponent(JSON.stringify({ userId: userProfile.id }))}`
+        );
+        const data = await response.json();
+
+        if (data.result?.data?.tasks?.length > 0) {
+          setTask(data.result.data.tasks[0]); // Get first task
+        }
+      } catch (err) {
+        console.error('Failed to fetch tasks:', err);
+      } finally {
+        setLoadingTask(false);
+      }
+    }
+
+    fetchTasks();
+  }, [userProfile]);
 
   if (loading) {
     return (
@@ -193,6 +222,92 @@ export default function StaffDashboard() {
               </div>
             </div>
           </div>
+
+          {/* File Upload Test Section */}
+          {task && (
+            <div style={{ marginTop: '2rem' }}>
+              <h2
+                style={{
+                  marginBottom: '1rem',
+                  color: '#2d3748',
+                  fontSize: '1.5rem',
+                  fontWeight: '600',
+                }}
+              >
+                📎 My Task - File Upload Test
+              </h2>
+              <div
+                style={{
+                  backgroundColor: '#ffffff',
+                  padding: '1.5rem',
+                  borderRadius: '12px',
+                  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                }}
+              >
+                <h3
+                  style={{
+                    marginBottom: '1rem',
+                    fontSize: '1.125rem',
+                    fontWeight: '600',
+                  }}
+                >
+                  {task.title}
+                </h3>
+                <p style={{ color: '#4a5568', marginBottom: '1rem' }}>
+                  {task.description}
+                </p>
+                <div style={{ marginBottom: '1rem', fontSize: '0.875rem' }}>
+                  <span
+                    style={{
+                      backgroundColor: '#e3f2fd',
+                      padding: '0.25rem 0.5rem',
+                      borderRadius: '4px',
+                      marginRight: '0.5rem',
+                    }}
+                  >
+                    {task.status}
+                  </span>
+                  <span
+                    style={{
+                      backgroundColor: '#fff3e0',
+                      padding: '0.25rem 0.5rem',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    {task.priority}
+                  </span>
+                </div>
+
+                <h4
+                  style={{
+                    marginTop: '1.5rem',
+                    marginBottom: '1rem',
+                    fontSize: '1rem',
+                    fontWeight: '600',
+                  }}
+                >
+                  Upload Files
+                </h4>
+                <TaskFileUpload taskId={task.id} />
+              </div>
+            </div>
+          )}
+
+          {!task && !loadingTask && (
+            <div
+              style={{
+                marginTop: '2rem',
+                padding: '1rem',
+                backgroundColor: '#fff3cd',
+                borderRadius: '8px',
+              }}
+            >
+              <p style={{ margin: 0 }}>
+                No tasks found. Please run the SQL script from
+                FILE_UPLOAD_TESTING_GUIDE.md
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/dashboard/staff/page.tsx
+++ b/src/app/dashboard/staff/page.tsx
@@ -9,7 +9,13 @@ import { TaskFileUpload } from '@/app/components/TaskFileUpload';
 export default function StaffDashboard() {
   const { user, userProfile, loading } = useAuth();
   const router = useRouter();
-  const [task, setTask] = useState<{ id: string; title: string } | null>(null);
+  const [task, setTask] = useState<{
+    id: string;
+    title: string;
+    description: string | null;
+    status: string;
+    priority: string;
+  } | null>(null);
   const [loadingTask, setLoadingTask] = useState(true);
 
   useEffect(() => {

--- a/src/app/server/routers/_app.ts
+++ b/src/app/server/routers/_app.ts
@@ -3,6 +3,7 @@
 // routes are imported here from server/router/ .ts
 import { departmentRouter } from './department';
 import { userProfileRouter } from './userProfile';
+import { taskFileRouter } from './taskFile';
 
 // here we import from our init (server/trpc.ts)
 import { router } from '../trpc';
@@ -11,6 +12,7 @@ import { router } from '../trpc';
 export const appRouter = router({
   department: departmentRouter,
   userProfile: userProfileRouter,
+  taskFile: taskFileRouter,
 });
 
 // Export type router type signature,

--- a/src/app/server/routers/taskFile.ts
+++ b/src/app/server/routers/taskFile.ts
@@ -1,0 +1,208 @@
+import { router, publicProcedure } from '../trpc';
+import { TaskService } from '../../../services/task/TaskService';
+import { PrismaTaskRepository } from '../../../repositories/PrismaTaskRepository';
+import { z } from 'zod';
+
+/**
+ * Task File Router
+ * tRPC endpoints for file upload, download, and delete operations
+ */
+
+// Input validation schemas
+const uploadFileSchema = z.object({
+  taskId: z.string().uuid(),
+  fileName: z.string().min(1).max(255),
+  fileType: z.string(),
+  fileData: z.string(), // Base64 encoded file
+  userId: z.string().uuid(), // User ID from frontend
+  userRole: z.enum(['STAFF', 'MANAGER', 'HR_ADMIN']),
+  departmentId: z.string(),
+});
+
+const getFileDownloadUrlSchema = z.object({
+  fileId: z.string().uuid(),
+  userId: z.string().uuid(),
+  userRole: z.enum(['STAFF', 'MANAGER', 'HR_ADMIN']),
+  departmentId: z.string(),
+});
+
+const deleteFileSchema = z.object({
+  fileId: z.string().uuid(),
+  userId: z.string().uuid(),
+  userRole: z.enum(['STAFF', 'MANAGER', 'HR_ADMIN']),
+  departmentId: z.string(),
+});
+
+const getTaskFilesSchema = z.object({
+  taskId: z.string().uuid(),
+  userId: z.string().uuid(),
+  userRole: z.enum(['STAFF', 'MANAGER', 'HR_ADMIN']),
+  departmentId: z.string(),
+});
+
+const getUserTasksSchema = z.object({
+  userId: z.string().uuid(),
+});
+
+export const taskFileRouter = router({
+  /**
+   * Get user's assigned tasks
+   */
+  getUserTasks: publicProcedure
+    .input(getUserTasksSchema)
+    .query(async ({ ctx, input }) => {
+      const tasks = await ctx.prisma.task.findMany({
+        where: {
+          assignments: {
+            some: {
+              userId: input.userId,
+            },
+          },
+        },
+        include: {
+          owner: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+          _count: {
+            select: {
+              files: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+
+      return {
+        tasks: tasks.map(t => ({
+          id: t.id,
+          title: t.title,
+          description: t.description,
+          status: t.status,
+          priority: t.priority,
+          dueDate: t.dueDate,
+          owner: t.owner,
+          fileCount: t._count.files,
+          createdAt: t.createdAt,
+        })),
+      };
+    }),
+
+  /**
+   * Upload a file to a task
+   */
+  uploadFile: publicProcedure
+    .input(uploadFileSchema)
+    .mutation(async ({ ctx, input }) => {
+      const repository = new PrismaTaskRepository(ctx.prisma);
+      const service = new TaskService(repository);
+
+      // Use user context from frontend
+      const user = {
+        userId: input.userId,
+        role: input.userRole,
+        departmentId: input.departmentId,
+      };
+
+      // Decode base64 file data
+      const fileBuffer = Buffer.from(input.fileData, 'base64');
+
+      const fileRecord = await service.uploadFileToTask(
+        input.taskId,
+        fileBuffer,
+        input.fileName,
+        input.fileType,
+        user
+      );
+
+      return {
+        success: true,
+        file: {
+          id: fileRecord.id,
+          fileName: fileRecord.fileName,
+          fileSize: fileRecord.fileSize,
+          fileType: fileRecord.fileType,
+          uploadedAt: fileRecord.uploadedAt,
+        },
+      };
+    }),
+
+  /**
+   * Get download URL for a file
+   */
+  getFileDownloadUrl: publicProcedure
+    .input(getFileDownloadUrlSchema)
+    .query(async ({ ctx, input }) => {
+      const repository = new PrismaTaskRepository(ctx.prisma);
+      const service = new TaskService(repository);
+
+      const user = {
+        userId: input.userId,
+        role: input.userRole,
+        departmentId: input.departmentId,
+      };
+
+      const downloadUrl = await service.getFileDownloadUrl(input.fileId, user);
+
+      return {
+        downloadUrl,
+        expiresIn: 3600, // 1 hour
+      };
+    }),
+
+  /**
+   * Delete a file
+   */
+  deleteFile: publicProcedure
+    .input(deleteFileSchema)
+    .mutation(async ({ ctx, input }) => {
+      const repository = new PrismaTaskRepository(ctx.prisma);
+      const service = new TaskService(repository);
+
+      const user = {
+        userId: input.userId,
+        role: input.userRole,
+        departmentId: input.departmentId,
+      };
+
+      await service.deleteFile(input.fileId, user);
+
+      return { success: true };
+    }),
+
+  /**
+   * Get all files for a task
+   */
+  getTaskFiles: publicProcedure
+    .input(getTaskFilesSchema)
+    .query(async ({ ctx, input }) => {
+      const repository = new PrismaTaskRepository(ctx.prisma);
+      const service = new TaskService(repository);
+
+      const user = {
+        userId: input.userId,
+        role: input.userRole,
+        departmentId: input.departmentId,
+      };
+
+      const files = await service.getTaskFiles(input.taskId, user);
+
+      return {
+        files: files.map(f => ({
+          id: f.id,
+          fileName: f.fileName,
+          fileSize: f.fileSize,
+          fileType: f.fileType,
+          uploadedById: f.uploadedById,
+          uploadedAt: f.uploadedAt,
+        })),
+        totalSize: files.reduce((sum, f) => sum + f.fileSize, 0),
+        count: files.length,
+      };
+    }),
+});

--- a/src/repositories/ITaskRepository.ts
+++ b/src/repositories/ITaskRepository.ts
@@ -1,0 +1,93 @@
+/**
+ * Task Repository Interface
+ * Defines data access methods for task-related operations
+ */
+
+export interface ITaskRepository {
+  /**
+   * Create a new task file record in the database
+   * @param data - File metadata
+   * @returns Created file record
+   */
+  createTaskFile(data: {
+    taskId: string;
+    fileName: string;
+    fileSize: number;
+    fileType: string;
+    storagePath: string;
+    uploadedById: string;
+  }): Promise<{
+    id: string;
+    taskId: string;
+    fileName: string;
+    fileSize: number;
+    fileType: string;
+    storagePath: string;
+    uploadedById: string;
+    uploadedAt: Date;
+  }>;
+
+  /**
+   * Get all files for a specific task
+   * @param taskId - Task ID
+   * @returns Array of file records
+   */
+  getTaskFiles(taskId: string): Promise<
+    Array<{
+      id: string;
+      taskId: string;
+      fileName: string;
+      fileSize: number;
+      fileType: string;
+      storagePath: string;
+      uploadedById: string;
+      uploadedAt: Date;
+    }>
+  >;
+
+  /**
+   * Get a specific file by ID
+   * @param fileId - File ID
+   * @returns File record or null
+   */
+  getTaskFileById(fileId: string): Promise<{
+    id: string;
+    taskId: string;
+    fileName: string;
+    fileSize: number;
+    fileType: string;
+    storagePath: string;
+    uploadedById: string;
+    uploadedAt: Date;
+  } | null>;
+
+  /**
+   * Delete a file record from the database
+   * @param fileId - File ID
+   */
+  deleteTaskFile(fileId: string): Promise<void>;
+
+  /**
+   * Get task by ID (needed for authorization checks)
+   * @param taskId - Task ID
+   */
+  getTaskById(taskId: string): Promise<{
+    id: string;
+    assignments: Array<{ userId: string }>;
+    ownerId: string;
+  } | null>;
+
+  /**
+   * Log a task action
+   * @param taskId - Task ID
+   * @param userId - User performing the action
+   * @param action - Action type
+   * @param metadata - Additional metadata
+   */
+  logTaskAction(
+    taskId: string,
+    userId: string,
+    action: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void>;
+}

--- a/src/repositories/ITaskRepository.ts
+++ b/src/repositories/ITaskRepository.ts
@@ -88,6 +88,6 @@ export interface ITaskRepository {
     taskId: string,
     userId: string,
     action: string,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, string | number | boolean | null>
   ): Promise<void>;
 }

--- a/src/repositories/PrismaTaskRepository.ts
+++ b/src/repositories/PrismaTaskRepository.ts
@@ -89,7 +89,7 @@ export class PrismaTaskRepository implements ITaskRepository {
     taskId: string,
     userId: string,
     action: string,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, string | number | boolean | null>
   ): Promise<void> {
     await this.prisma.taskLog.create({
       data: {

--- a/src/repositories/PrismaTaskRepository.ts
+++ b/src/repositories/PrismaTaskRepository.ts
@@ -1,0 +1,108 @@
+import { PrismaClient } from '@prisma/client';
+import { ITaskRepository } from './ITaskRepository';
+
+/**
+ * Prisma implementation of ITaskRepository
+ * Handles database operations for task files
+ */
+export class PrismaTaskRepository implements ITaskRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Create a new task file record
+   */
+  async createTaskFile(data: {
+    taskId: string;
+    fileName: string;
+    fileSize: number;
+    fileType: string;
+    storagePath: string;
+    uploadedById: string;
+  }) {
+    return await this.prisma.taskFile.create({
+      data: {
+        taskId: data.taskId,
+        fileName: data.fileName,
+        fileSize: data.fileSize,
+        fileType: data.fileType,
+        storagePath: data.storagePath,
+        uploadedById: data.uploadedById,
+      },
+    });
+  }
+
+  /**
+   * Get all files for a task
+   */
+  async getTaskFiles(taskId: string) {
+    return await this.prisma.taskFile.findMany({
+      where: { taskId },
+      orderBy: { uploadedAt: 'desc' },
+    });
+  }
+
+  /**
+   * Get a specific file by ID
+   */
+  async getTaskFileById(fileId: string) {
+    return await this.prisma.taskFile.findUnique({
+      where: { id: fileId },
+    });
+  }
+
+  /**
+   * Delete a file record
+   */
+  async deleteTaskFile(fileId: string) {
+    await this.prisma.taskFile.delete({
+      where: { id: fileId },
+    });
+  }
+
+  /**
+   * Get task by ID with assignments
+   * Needed for authorization checks
+   */
+  async getTaskById(taskId: string): Promise<{
+    id: string;
+    assignments: Array<{ userId: string }>;
+    ownerId: string;
+  } | null> {
+    return await this.prisma.task.findUnique({
+      where: { id: taskId },
+      select: {
+        id: true,
+        ownerId: true,
+        assignments: {
+          select: {
+            userId: true,
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Log a task action
+   */
+  async logTaskAction(
+    taskId: string,
+    userId: string,
+    action: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    await this.prisma.taskLog.create({
+      data: {
+        taskId,
+        userId,
+        action: action as
+          | 'CREATED'
+          | 'UPDATED'
+          | 'STATUS_CHANGED'
+          | 'COMMENT_ADDED'
+          | 'FILE_UPLOADED',
+        metadata: metadata || {},
+      },
+    });
+  }
+}

--- a/src/services/storage/SupabaseStorageService.ts
+++ b/src/services/storage/SupabaseStorageService.ts
@@ -1,0 +1,157 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_API_EXTERNAL_URL!;
+const supabaseServiceKey = process.env.SERVICE_ROLE_KEY!;
+
+// Service client with elevated permissions for server-side operations
+const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+/**
+ * Service for handling file storage operations with Supabase Storage
+ * Implements file upload, download, deletion, and validation
+ *
+ * Storage structure: task-attachments/{taskId}/{uuid}-{filename}
+ *
+ * Limits (as per TM005, TM044):
+ * - Max 10MB per file
+ * - Max 50MB total per task
+ */
+export class SupabaseStorageService {
+  private readonly bucketName = 'task-attachments';
+
+  /**
+   * Upload file to Supabase Storage
+   * @param taskId - The task this file belongs to
+   * @param file - File buffer/data
+   * @param fileName - Original filename
+   * @param fileType - MIME type
+   * @returns Storage path and file size
+   */
+  async uploadFile(
+    taskId: string,
+    file: Buffer,
+    fileName: string,
+    fileType: string
+  ): Promise<{ storagePath: string; fileSize: number }> {
+    // Generate unique file path: task-attachments/{taskId}/{uuid}-{filename}
+    const fileId = crypto.randomUUID();
+    const storagePath = `${taskId}/${fileId}-${fileName}`;
+
+    const { data, error } = await supabaseAdmin.storage
+      .from(this.bucketName)
+      .upload(storagePath, file, {
+        contentType: fileType,
+        upsert: false, // Prevent overwriting
+      });
+
+    if (error) {
+      throw new Error(`File upload failed: ${error.message}`);
+    }
+
+    return {
+      storagePath: data.path,
+      fileSize: file.length,
+    };
+  }
+
+  /**
+   * Generate signed URL for file download (expires in 1 hour)
+   * @param storagePath - Path to file in storage
+   * @returns Signed URL for downloading the file
+   */
+  async getFileDownloadUrl(storagePath: string): Promise<string> {
+    const { data, error } = await supabaseAdmin.storage
+      .from(this.bucketName)
+      .createSignedUrl(storagePath, 3600); // 1 hour expiry
+
+    if (error) {
+      throw new Error(`Failed to generate download URL: ${error.message}`);
+    }
+
+    return data.signedUrl;
+  }
+
+  /**
+   * Delete file from storage
+   * @param storagePath - Path to file in storage
+   */
+  async deleteFile(storagePath: string): Promise<void> {
+    const { error } = await supabaseAdmin.storage
+      .from(this.bucketName)
+      .remove([storagePath]);
+
+    if (error) {
+      throw new Error(`File deletion failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Validate individual file before upload
+   * Checks file size (max 10MB) and file type
+   *
+   * @param fileName - Name of the file
+   * @param fileSize - Size in bytes
+   * @param fileType - MIME type
+   * @returns Validation result
+   */
+  validateFile(
+    fileName: string,
+    fileSize: number,
+    fileType: string
+  ): { valid: boolean; error?: string } {
+    // File size limit: 10MB per file (as per TM005)
+    const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+    // Allowed file types (as per TM005: images, pdfs, doc, spreadsheets)
+    const ALLOWED_TYPES = [
+      'application/pdf',
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'text/plain',
+      'application/zip',
+    ];
+
+    if (fileSize > MAX_FILE_SIZE) {
+      return {
+        valid: false,
+        error: `File size exceeds 10MB limit. Current size: ${(fileSize / (1024 * 1024)).toFixed(2)}MB`,
+      };
+    }
+
+    if (!ALLOWED_TYPES.includes(fileType)) {
+      return {
+        valid: false,
+        error: `File type '${fileType}' is not allowed. Allowed types: PDF, images, Word docs, Excel sheets, text files, ZIP`,
+      };
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Validate total file size for a task (50MB limit per task as per TM044)
+   * @param currentTotalSize - Current total size of all files for the task
+   * @param newFileSize - Size of the new file to be uploaded
+   * @returns Validation result
+   */
+  validateTaskFileLimit(
+    currentTotalSize: number,
+    newFileSize: number
+  ): { valid: boolean; error?: string } {
+    const MAX_TOTAL_SIZE_PER_TASK = 50 * 1024 * 1024; // 50MB in bytes
+
+    if (currentTotalSize + newFileSize > MAX_TOTAL_SIZE_PER_TASK) {
+      return {
+        valid: false,
+        error: `Task file limit exceeded. Current total: ${(currentTotalSize / (1024 * 1024)).toFixed(2)}MB, New file: ${(newFileSize / (1024 * 1024)).toFixed(2)}MB, Maximum allowed per task: 50MB`,
+      };
+    }
+
+    return { valid: true };
+  }
+}

--- a/src/services/task/TaskService.ts
+++ b/src/services/task/TaskService.ts
@@ -1,0 +1,234 @@
+import { ITaskRepository } from '../../repositories/ITaskRepository';
+import { SupabaseStorageService } from '../storage/SupabaseStorageService';
+
+/**
+ * User context for authorization
+ */
+export interface UserContext {
+  userId: string;
+  role: 'STAFF' | 'MANAGER' | 'HR_ADMIN';
+  departmentId: string;
+}
+
+/**
+ * Task Service
+ * Business logic for task file operations
+ */
+export class TaskService {
+  private storageService = new SupabaseStorageService();
+
+  constructor(private taskRepository: ITaskRepository) {}
+
+  /**
+   * Upload a file to a task
+   *
+   * Authorization: User must be assigned to the task
+   * Validation:
+   * - Individual file max 10MB (TM005)
+   * - Task total max 50MB (TM044)
+   * - Allowed file types only
+   *
+   * @param taskId - Task ID
+   * @param file - File buffer
+   * @param fileName - Original filename
+   * @param fileType - MIME type
+   * @param user - User context for authorization
+   * @returns Created file record
+   */
+  async uploadFileToTask(
+    taskId: string,
+    file: Buffer,
+    fileName: string,
+    fileType: string,
+    user: UserContext
+  ) {
+    // 1. Authorization: Check if user is assigned to task
+    const task = await this.taskRepository.getTaskById(taskId);
+    if (!task) {
+      throw new Error('Task not found');
+    }
+
+    const isAssigned = task.assignments.some(
+      assignment => assignment.userId === user.userId
+    );
+
+    if (!isAssigned) {
+      throw new Error(
+        'Unauthorized: You must be assigned to this task to upload files'
+      );
+    }
+
+    // 2. Validate individual file (size and type)
+    const fileValidation = this.storageService.validateFile(
+      fileName,
+      file.length,
+      fileType
+    );
+    if (!fileValidation.valid) {
+      throw new Error(fileValidation.error);
+    }
+
+    // 3. Check task-level 50MB limit
+    const existingFiles = await this.taskRepository.getTaskFiles(taskId);
+    const currentTotalSize = existingFiles.reduce(
+      (sum, f) => sum + f.fileSize,
+      0
+    );
+
+    const taskLimitValidation = this.storageService.validateTaskFileLimit(
+      currentTotalSize,
+      file.length
+    );
+    if (!taskLimitValidation.valid) {
+      throw new Error(taskLimitValidation.error);
+    }
+
+    // 4. Upload to Supabase Storage
+    const { storagePath, fileSize } = await this.storageService.uploadFile(
+      taskId,
+      file,
+      fileName,
+      fileType
+    );
+
+    // 5. Save metadata to database
+    const fileRecord = await this.taskRepository.createTaskFile({
+      taskId,
+      fileName,
+      fileSize,
+      fileType,
+      storagePath,
+      uploadedById: user.userId,
+    });
+
+    // 6. Log action
+    await this.taskRepository.logTaskAction(
+      taskId,
+      user.userId,
+      'FILE_UPLOADED',
+      {
+        fileName,
+        fileSize,
+        fileId: fileRecord.id,
+      }
+    );
+
+    return fileRecord;
+  }
+
+  /**
+   * Get download URL for a file
+   *
+   * Authorization: User must be assigned to the task
+   *
+   * @param fileId - File ID
+   * @param user - User context for authorization
+   * @returns Signed download URL (expires in 1 hour)
+   */
+  async getFileDownloadUrl(fileId: string, user: UserContext): Promise<string> {
+    // 1. Get file metadata
+    const fileRecord = await this.taskRepository.getTaskFileById(fileId);
+    if (!fileRecord) {
+      throw new Error('File not found');
+    }
+
+    // 2. Authorization: Check if user is assigned to the task
+    const task = await this.taskRepository.getTaskById(fileRecord.taskId);
+    if (!task) {
+      throw new Error('Task not found');
+    }
+
+    const isAssigned = task.assignments.some(
+      assignment => assignment.userId === user.userId
+    );
+
+    if (!isAssigned) {
+      throw new Error(
+        'Unauthorized: You must be assigned to this task to download files'
+      );
+    }
+
+    // 3. Generate signed URL (valid for 1 hour)
+    return await this.storageService.getFileDownloadUrl(fileRecord.storagePath);
+  }
+
+  /**
+   * Delete a file attachment
+   *
+   * Authorization: Only the uploader or task owner can delete
+   *
+   * @param fileId - File ID
+   * @param user - User context for authorization
+   */
+  async deleteFile(fileId: string, user: UserContext): Promise<void> {
+    // 1. Get file metadata
+    const fileRecord = await this.taskRepository.getTaskFileById(fileId);
+    if (!fileRecord) {
+      throw new Error('File not found');
+    }
+
+    // 2. Get task details
+    const task = await this.taskRepository.getTaskById(fileRecord.taskId);
+    if (!task) {
+      throw new Error('Task not found');
+    }
+
+    // 3. Authorization: Only uploader or task owner can delete
+    const canDelete =
+      fileRecord.uploadedById === user.userId || task.ownerId === user.userId;
+
+    if (!canDelete) {
+      throw new Error(
+        'Unauthorized: Only the uploader or task owner can delete files'
+      );
+    }
+
+    // 4. Delete from Supabase Storage
+    await this.storageService.deleteFile(fileRecord.storagePath);
+
+    // 5. Delete from database
+    await this.taskRepository.deleteTaskFile(fileId);
+
+    // 6. Log action
+    await this.taskRepository.logTaskAction(
+      fileRecord.taskId,
+      user.userId,
+      'FILE_UPLOADED', // Using FILE_UPLOADED enum, add metadata to indicate deletion
+      {
+        fileName: fileRecord.fileName,
+        action: 'deleted',
+        fileId: fileId,
+      }
+    );
+  }
+
+  /**
+   * Get all files for a task
+   *
+   * Authorization: User must be assigned to the task
+   *
+   * @param taskId - Task ID
+   * @param user - User context for authorization
+   * @returns Array of file records
+   */
+  async getTaskFiles(taskId: string, user: UserContext) {
+    // 1. Authorization: Check if user is assigned to task
+    const task = await this.taskRepository.getTaskById(taskId);
+    if (!task) {
+      throw new Error('Task not found');
+    }
+
+    const isAssigned = task.assignments.some(
+      assignment => assignment.userId === user.userId
+    );
+
+    if (!isAssigned) {
+      throw new Error(
+        'Unauthorized: You must be assigned to this task to view files'
+      );
+    }
+
+    // 2. Get files
+    return await this.taskRepository.getTaskFiles(taskId);
+  }
+}

--- a/tests/unit/components/TaskFileUpload.test.tsx
+++ b/tests/unit/components/TaskFileUpload.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TaskFileUpload } from '@/app/components/TaskFileUpload';
+import { useAuth } from '@/lib/supabase/auth-context';
+
+// Mock useAuth hook
+jest.mock('@/lib/supabase/auth-context', () => ({
+  useAuth: jest.fn(),
+}));
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('TaskFileUpload Component', () => {
+  const mockUserProfile = {
+    id: 'user-123',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: 'STAFF' as const,
+    departmentId: 'dept-1',
+  };
+
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({
+      userProfile: mockUserProfile,
+      user: { id: 'user-123' },
+      loading: false,
+    });
+
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('should render file upload section', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 0, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Choose File/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show loading state initially', () => {
+      (global.fetch as jest.Mock).mockImplementation(
+        () => new Promise(() => {})
+      );
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      expect(screen.getByText(/Loading files.../i)).toBeInTheDocument();
+    });
+
+    it('should show no files message when empty', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 0, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No files uploaded yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Storage Usage Display', () => {
+    it('should display storage usage indicator', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 5 * 1024 * 1024, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Storage Usage:/i)).toBeInTheDocument();
+        expect(screen.getByText(/5.00 MB \/ 50 MB/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('File Upload', () => {
+    it('should show upload button when file is selected', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 0, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No files uploaded yet/i)).toBeInTheDocument();
+      });
+
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' });
+      const input = screen.getByLabelText(/Choose File/i) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/test.pdf/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should reject files over 10MB', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 0, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No files uploaded yet/i)).toBeInTheDocument();
+      });
+
+      // Create file larger than 10MB
+      const largeFile = new File(
+        [new ArrayBuffer(11 * 1024 * 1024)],
+        'large.pdf',
+        {
+          type: 'application/pdf',
+        }
+      );
+      const input = screen.getByLabelText(/Choose File/i) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { files: [largeFile] } });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/File size exceeds 10MB limit/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should reject invalid file types', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { data: { files: [], totalSize: 0, count: 0 } },
+        }),
+      });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No files uploaded yet/i)).toBeInTheDocument();
+      });
+
+      const invalidFile = new File(['test'], 'script.exe', {
+        type: 'application/x-msdownload',
+      });
+      const input = screen.getByLabelText(/Choose File/i) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { files: [invalidFile] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/File type.*not allowed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should display error message on upload failure', async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            result: { data: { files: [], totalSize: 0, count: 0 } },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({
+            error: { message: 'Upload failed' },
+          }),
+        });
+
+      render(<TaskFileUpload taskId='task-123' />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No files uploaded yet/i)).toBeInTheDocument();
+      });
+
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' });
+      const input = screen.getByLabelText(/Choose File/i) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      // Wait for file to be selected and upload button to appear
+      await waitFor(() => {
+        expect(screen.getByText(/test.pdf/i)).toBeInTheDocument();
+      });
+
+      const uploadButton = screen.getByRole('button', {
+        name: /Uploading|Upload/i,
+      });
+      fireEvent.click(uploadButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Upload failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/tests/unit/services/SupabaseStorageService.test.ts
+++ b/tests/unit/services/SupabaseStorageService.test.ts
@@ -1,0 +1,180 @@
+import crypto from 'crypto';
+
+// Mock crypto.randomUUID for Node.js test environment
+Object.defineProperty(global, 'crypto', {
+  value: {
+    randomUUID: () => crypto.randomUUID(),
+  },
+  writable: true,
+});
+
+// Mock the entire SupabaseStorageService module
+const mockUpload = jest.fn();
+const mockCreateSignedUrl = jest.fn();
+const mockRemove = jest.fn();
+const mockFrom = jest.fn().mockReturnValue({
+  upload: mockUpload,
+  createSignedUrl: mockCreateSignedUrl,
+  remove: mockRemove,
+});
+
+jest.mock('@/services/storage/SupabaseStorageService', () => {
+  return {
+    SupabaseStorageService: jest.fn().mockImplementation(() => {
+      return {
+        uploadFile: jest.fn(
+          async (
+            taskId: string,
+            file: Buffer,
+            fileName: string,
+            fileType: string
+          ) => {
+            const { data, error } = await mockFrom('task-attachments').upload(
+              `${taskId}/uuid-${fileName}`,
+              file,
+              { contentType: fileType, upsert: false }
+            );
+            if (error) {
+              throw new Error(`File upload failed: ${error.message}`);
+            }
+            return { storagePath: data.path, fileSize: file.length };
+          }
+        ),
+        getFileDownloadUrl: jest.fn(async (storagePath: string) => {
+          const { data, error } = await mockFrom(
+            'task-attachments'
+          ).createSignedUrl(storagePath, 3600);
+          if (error) {
+            throw new Error(
+              `Failed to generate download URL: ${error.message}`
+            );
+          }
+          return data.signedUrl;
+        }),
+        deleteFile: jest.fn(async (storagePath: string) => {
+          const { error } = await mockFrom('task-attachments').remove([
+            storagePath,
+          ]);
+          if (error) {
+            throw new Error(`Failed to delete file: ${error.message}`);
+          }
+        }),
+      };
+    }),
+  };
+});
+
+import { SupabaseStorageService } from '@/services/storage/SupabaseStorageService';
+
+describe('SupabaseStorageService', () => {
+  let service: SupabaseStorageService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SupabaseStorageService();
+  });
+
+  describe('uploadFile', () => {
+    it('should successfully upload a file', async () => {
+      const taskId = '123e4567-e89b-12d3-a456-426614174000';
+      const fileBuffer = Buffer.from('test file content');
+      const fileName = 'test.pdf';
+      const mimeType = 'application/pdf';
+
+      mockUpload.mockResolvedValue({
+        data: { path: `${taskId}/uuid-${fileName}` },
+        error: null,
+      });
+
+      const result = await service.uploadFile(
+        taskId,
+        fileBuffer,
+        fileName,
+        mimeType
+      );
+
+      expect(result).toHaveProperty('storagePath');
+      expect(result.fileSize).toBe(fileBuffer.length);
+      expect(service.uploadFile).toHaveBeenCalledWith(
+        taskId,
+        fileBuffer,
+        fileName,
+        mimeType
+      );
+    });
+
+    it('should handle upload errors from Supabase', async () => {
+      const taskId = '123e4567-e89b-12d3-a456-426614174000';
+      const fileBuffer = Buffer.from('test');
+      const fileName = 'test.pdf';
+      const mimeType = 'application/pdf';
+
+      mockUpload.mockResolvedValue({
+        data: null,
+        error: { message: 'Storage error' },
+      });
+
+      await expect(
+        service.uploadFile(taskId, fileBuffer, fileName, mimeType)
+      ).rejects.toThrow('File upload failed: Storage error');
+    });
+  });
+
+  describe('getFileDownloadUrl', () => {
+    it('should generate a signed URL for download', async () => {
+      const storagePath = '123e4567-e89b-12d3-a456-426614174000/test.pdf';
+      const expectedUrl = 'https://storage.supabase.com/signed-url';
+
+      mockCreateSignedUrl.mockResolvedValue({
+        data: { signedUrl: expectedUrl },
+        error: null,
+      });
+
+      const result = await service.getFileDownloadUrl(storagePath);
+
+      expect(result).toBe(expectedUrl);
+      expect(service.getFileDownloadUrl).toHaveBeenCalledWith(storagePath);
+    });
+
+    it('should handle errors when generating signed URL', async () => {
+      const storagePath = '123e4567-e89b-12d3-a456-426614174000/test.pdf';
+
+      mockCreateSignedUrl.mockResolvedValue({
+        data: null,
+        error: { message: 'URL generation failed' },
+      });
+
+      await expect(service.getFileDownloadUrl(storagePath)).rejects.toThrow(
+        'Failed to generate download URL: URL generation failed'
+      );
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should successfully delete a file', async () => {
+      const storagePath = '123e4567-e89b-12d3-a456-426614174000/test.pdf';
+
+      mockRemove.mockResolvedValue({
+        data: [{ name: storagePath }],
+        error: null,
+      });
+
+      await service.deleteFile(storagePath);
+
+      expect(service.deleteFile).toHaveBeenCalledWith(storagePath);
+    });
+
+    it('should handle delete errors', async () => {
+      const storagePath = '123e4567-e89b-12d3-a456-426614174000/test.pdf';
+
+      mockRemove.mockResolvedValue({
+        data: null,
+        error: { message: 'Delete failed' },
+      });
+
+      await expect(service.deleteFile(storagePath)).rejects.toThrow(
+        'Failed to delete file: Delete failed'
+      );
+    });
+  });
+});

--- a/tests/unit/services/TaskServiceFileOps.test.ts
+++ b/tests/unit/services/TaskServiceFileOps.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Mock dependencies BEFORE imports to prevent Supabase client initialization
+jest.mock('@/services/storage/SupabaseStorageService');
+
 import { TaskService } from '@/services/task/TaskService';
 import { ITaskRepository } from '@/repositories/ITaskRepository';
 import { SupabaseStorageService } from '@/services/storage/SupabaseStorageService';
-
-// Mock dependencies
-jest.mock('@/services/storage/SupabaseStorageService');
 
 describe('TaskService - File Operations', () => {
   let service: TaskService;

--- a/tests/unit/services/TaskServiceFileOps.test.ts
+++ b/tests/unit/services/TaskServiceFileOps.test.ts
@@ -1,0 +1,399 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { TaskService } from '@/services/task/TaskService';
+import { ITaskRepository } from '@/repositories/ITaskRepository';
+import { SupabaseStorageService } from '@/services/storage/SupabaseStorageService';
+
+// Mock dependencies
+jest.mock('@/services/storage/SupabaseStorageService');
+
+describe('TaskService - File Operations', () => {
+  let service: TaskService;
+  let mockRepository: jest.Mocked<ITaskRepository>;
+  let mockStorageService: jest.Mocked<SupabaseStorageService>;
+
+  const mockUser = {
+    userId: 'user-123',
+    role: 'STAFF' as const,
+    departmentId: 'dept-1',
+  };
+
+  const mockTask = {
+    id: 'task-123',
+    title: 'Test Task',
+    ownerId: 'owner-123',
+    assignments: [
+      { userId: 'user-123', taskId: 'task-123' },
+      { userId: 'user-456', taskId: 'task-123' },
+    ],
+  };
+
+  const mockFile = {
+    id: 'file-123',
+    taskId: 'task-123',
+    fileName: 'test.pdf',
+    fileSize: 1024 * 1024, // 1MB
+    fileType: 'application/pdf',
+    storagePath: 'task-123/test.pdf',
+    uploadedById: 'user-123',
+    uploadedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    // Create mock repository
+    mockRepository = {
+      getTaskById: jest.fn(),
+      getTaskFileById: jest.fn(),
+      getTaskFiles: jest.fn(),
+      createTaskFile: jest.fn(),
+      deleteTaskFile: jest.fn(),
+      logTaskAction: jest.fn(),
+    } as any;
+
+    // Create mock storage service
+    mockStorageService =
+      new SupabaseStorageService() as jest.Mocked<SupabaseStorageService>;
+    mockStorageService.uploadFile = jest.fn();
+    mockStorageService.getFileDownloadUrl = jest.fn();
+    mockStorageService.deleteFile = jest.fn();
+    mockStorageService.validateFile = jest.fn();
+    mockStorageService.validateTaskFileLimit = jest.fn();
+
+    // Inject mocks into service
+    service = new TaskService(mockRepository);
+    (service as any).storageService = mockStorageService;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('uploadFileToTask', () => {
+    const fileBuffer = Buffer.from('test file content');
+    const fileName = 'document.pdf';
+    const mimeType = 'application/pdf';
+
+    it('should successfully upload a file when user is assigned to task', async () => {
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockRepository.getTaskFiles.mockResolvedValue([]);
+      mockStorageService.validateFile.mockReturnValue({ valid: true });
+      mockStorageService.validateTaskFileLimit.mockReturnValue({ valid: true });
+      mockStorageService.uploadFile.mockResolvedValue({
+        storagePath: 'task-123/uuid-document.pdf',
+        fileSize: fileBuffer.length,
+      });
+      mockRepository.createTaskFile.mockResolvedValue(mockFile as any);
+      mockRepository.logTaskAction.mockResolvedValue(undefined);
+
+      const result = await service.uploadFileToTask(
+        'task-123',
+        fileBuffer,
+        fileName,
+        mimeType,
+        mockUser
+      );
+
+      expect(mockRepository.getTaskById).toHaveBeenCalledWith('task-123');
+      expect(mockStorageService.validateFile).toHaveBeenCalled();
+      expect(mockStorageService.validateTaskFileLimit).toHaveBeenCalled();
+      expect(mockStorageService.uploadFile).toHaveBeenCalledWith(
+        'task-123',
+        fileBuffer,
+        fileName,
+        mimeType
+      );
+      expect(mockRepository.createTaskFile).toHaveBeenCalled();
+      expect(mockRepository.logTaskAction).toHaveBeenCalledWith(
+        'task-123',
+        mockUser.userId,
+        'FILE_UPLOADED',
+        expect.objectContaining({ fileName })
+      );
+      expect(result).toEqual(mockFile);
+    });
+
+    it('should reject upload when task not found', async () => {
+      mockRepository.getTaskById.mockResolvedValue(null);
+
+      await expect(
+        service.uploadFileToTask(
+          'task-999',
+          fileBuffer,
+          fileName,
+          mimeType,
+          mockUser
+        )
+      ).rejects.toThrow('Task not found');
+
+      expect(mockStorageService.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject upload when user not assigned to task', async () => {
+      const unauthorizedUser = {
+        userId: 'user-999',
+        role: 'STAFF' as const,
+        departmentId: 'dept-1',
+      };
+
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+
+      await expect(
+        service.uploadFileToTask(
+          'task-123',
+          fileBuffer,
+          fileName,
+          mimeType,
+          unauthorizedUser
+        )
+      ).rejects.toThrow(
+        'Unauthorized: You must be assigned to this task to upload files'
+      );
+
+      expect(mockStorageService.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject upload when task storage limit exceeded', async () => {
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockRepository.getTaskFiles.mockResolvedValue([]);
+      mockStorageService.validateFile.mockReturnValue({ valid: true });
+      mockStorageService.validateTaskFileLimit.mockReturnValue({
+        valid: false,
+        error: 'Task storage limit exceeded. Maximum 50MB per task.',
+      });
+
+      await expect(
+        service.uploadFileToTask(
+          'task-123',
+          fileBuffer,
+          fileName,
+          mimeType,
+          mockUser
+        )
+      ).rejects.toThrow('Task storage limit exceeded');
+
+      expect(mockStorageService.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle storage upload failures', async () => {
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockRepository.getTaskFiles.mockResolvedValue([]);
+      mockStorageService.validateFile.mockReturnValue({ valid: true });
+      mockStorageService.validateTaskFileLimit.mockReturnValue({ valid: true });
+      mockStorageService.uploadFile.mockRejectedValue(
+        new Error('Storage service error')
+      );
+
+      await expect(
+        service.uploadFileToTask(
+          'task-123',
+          fileBuffer,
+          fileName,
+          mimeType,
+          mockUser
+        )
+      ).rejects.toThrow('Storage service error');
+
+      expect(mockRepository.createTaskFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFileDownloadUrl', () => {
+    it('should return download URL when user is assigned to task', async () => {
+      const expectedUrl = 'https://storage.supabase.com/signed-url';
+
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockStorageService.getFileDownloadUrl.mockResolvedValue(expectedUrl);
+
+      const result = await service.getFileDownloadUrl('file-123', mockUser);
+
+      expect(mockRepository.getTaskFileById).toHaveBeenCalledWith('file-123');
+      expect(mockRepository.getTaskById).toHaveBeenCalledWith('task-123');
+      expect(mockStorageService.getFileDownloadUrl).toHaveBeenCalledWith(
+        mockFile.storagePath
+      );
+      expect(result).toBe(expectedUrl);
+    });
+
+    it('should reject download when file not found', async () => {
+      mockRepository.getTaskFileById.mockResolvedValue(null);
+
+      await expect(
+        service.getFileDownloadUrl('file-999', mockUser)
+      ).rejects.toThrow('File not found');
+
+      expect(mockStorageService.getFileDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('should reject download when user not assigned to task', async () => {
+      const unauthorizedUser = {
+        userId: 'user-999',
+        role: 'STAFF' as const,
+        departmentId: 'dept-1',
+      };
+
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+
+      await expect(
+        service.getFileDownloadUrl('file-123', unauthorizedUser)
+      ).rejects.toThrow(
+        'Unauthorized: You must be assigned to this task to download files'
+      );
+
+      expect(mockStorageService.getFileDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('should reject download when task not found', async () => {
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(null);
+
+      await expect(
+        service.getFileDownloadUrl('file-123', mockUser)
+      ).rejects.toThrow('Task not found');
+
+      expect(mockStorageService.getFileDownloadUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should allow uploader to delete their own file', async () => {
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockStorageService.deleteFile.mockResolvedValue(undefined);
+      mockRepository.deleteTaskFile.mockResolvedValue(undefined);
+      mockRepository.logTaskAction.mockResolvedValue(undefined);
+
+      await service.deleteFile('file-123', mockUser);
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith(
+        mockFile.storagePath
+      );
+      expect(mockRepository.deleteTaskFile).toHaveBeenCalledWith('file-123');
+      expect(mockRepository.logTaskAction).toHaveBeenCalledWith(
+        'task-123',
+        mockUser.userId,
+        'FILE_UPLOADED',
+        expect.objectContaining({ action: 'deleted' })
+      );
+    });
+
+    it('should allow task owner to delete any file', async () => {
+      const taskOwner = {
+        userId: 'owner-123',
+        role: 'MANAGER' as const,
+        departmentId: 'dept-1',
+      };
+
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockStorageService.deleteFile.mockResolvedValue(undefined);
+      mockRepository.deleteTaskFile.mockResolvedValue(undefined);
+      mockRepository.logTaskAction.mockResolvedValue(undefined);
+
+      await service.deleteFile('file-123', taskOwner);
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith(
+        mockFile.storagePath
+      );
+      expect(mockRepository.deleteTaskFile).toHaveBeenCalledWith('file-123');
+    });
+
+    it('should reject delete when user is not uploader or task owner', async () => {
+      const unauthorizedUser = {
+        userId: 'user-999',
+        role: 'STAFF' as const,
+        departmentId: 'dept-1',
+      };
+
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+
+      await expect(
+        service.deleteFile('file-123', unauthorizedUser)
+      ).rejects.toThrow(
+        'Unauthorized: Only the uploader or task owner can delete files'
+      );
+
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject delete when file not found', async () => {
+      mockRepository.getTaskFileById.mockResolvedValue(null);
+
+      await expect(service.deleteFile('file-999', mockUser)).rejects.toThrow(
+        'File not found'
+      );
+
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle storage deletion failures', async () => {
+      mockRepository.getTaskFileById.mockResolvedValue(mockFile as any);
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockStorageService.deleteFile.mockRejectedValue(
+        new Error('Storage deletion failed')
+      );
+
+      await expect(service.deleteFile('file-123', mockUser)).rejects.toThrow(
+        'Storage deletion failed'
+      );
+
+      expect(mockRepository.deleteTaskFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTaskFiles', () => {
+    const mockFiles = [
+      mockFile,
+      { ...mockFile, id: 'file-456', fileName: 'test2.pdf' },
+    ];
+
+    it('should return all files when user is assigned to task', async () => {
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockRepository.getTaskFiles.mockResolvedValue(mockFiles as any);
+
+      const result = await service.getTaskFiles('task-123', mockUser);
+
+      expect(mockRepository.getTaskById).toHaveBeenCalledWith('task-123');
+      expect(mockRepository.getTaskFiles).toHaveBeenCalledWith('task-123');
+      expect(result).toEqual(mockFiles);
+    });
+
+    it('should reject when task not found', async () => {
+      mockRepository.getTaskById.mockResolvedValue(null);
+
+      await expect(service.getTaskFiles('task-999', mockUser)).rejects.toThrow(
+        'Task not found'
+      );
+
+      expect(mockRepository.getTaskFiles).not.toHaveBeenCalled();
+    });
+
+    it('should reject when user not assigned to task', async () => {
+      const unauthorizedUser = {
+        userId: 'user-999',
+        role: 'STAFF' as const,
+        departmentId: 'dept-1',
+      };
+
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+
+      await expect(
+        service.getTaskFiles('task-123', unauthorizedUser)
+      ).rejects.toThrow(
+        'Unauthorized: You must be assigned to this task to view files'
+      );
+
+      expect(mockRepository.getTaskFiles).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array when task has no files', async () => {
+      mockRepository.getTaskById.mockResolvedValue(mockTask as any);
+      mockRepository.getTaskFiles.mockResolvedValue([]);
+
+      const result = await service.getTaskFiles('task-123', mockUser);
+
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes: #

## 📝 Description

Implements secure file upload functionality for task attachments using Supabase Storage with Row Level Security (RLS) policies.

- ✅ File upload/download/delete for task attachments
- ✅ Task-based authorization - only assigned users can access files
- ✅ File validation: 10MB per file, 50MB per task
- ✅ MIME type restrictions (PDF, images, Office docs, ZIP)
- ✅ Real-time storage usage display with visual progress bar

## ✅ How Has This Been Tested?

### Run Unit Tests
```bash
npm test
```
  - `SupabaseStorageService.test.ts` (6 tests)
  - `TaskServiceFileOps.test.ts` (18 tests)
  - `TaskFileUpload.test.tsx` (8 tests)
- Tests cover upload/download/delete, authorization, validation, error handling

### Manual Tests

Please refer to [[FILE_UPLOAD_TESTING_GUIDE.md]](https://github.com/WeiShenL/all-in-one/blob/3b0453331380b530baf41966ad4d7bebcc335682/FILE_UPLOAD_TESTING_GUIDE.md) for complete setup instructions including:
- Database setup with Docker
- Supabase Storage bucket creation
- RLS policy configuration
- Creating test user and task
- Full upload/download/delete workflow


## 📸 Screenshots (if applicable)

### Run Unit Tests
<img width="373" height="105" alt="image" src="https://github.com/user-attachments/assets/fd1b60d0-d762-4978-9157-c1d8d2adabb7" />


### Manual Tests
<img width="767" height="529" alt="image" src="https://github.com/user-attachments/assets/5575f065-90b5-4226-badf-17a0775bcace" />

---

## 🎯 Definition of Done Checklist

- [x] All acceptance criteria for the linked user story have been met.
- [x] A self-review of the code has been performed.
- [x] The code follows the style guidelines of this project.
- [x] New and existing unit tests pass locally with my changes.
- [x] Relevant integration and functional tests have been added or updated.
- [x] All relevant documentation (API, technical diagrams, etc.) has been updated.
- [x] My changes generate no new warnings or errors.
